### PR TITLE
Compatibility with latest em-redis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ group :development do
   gem 'bson_ext'
   gem 'mysqlplus'
   gem 'em-mysqlplus'
-  gem 'em-redis'
+  gem 'em-redis', '~> 0.3.0'
   gem 'mongo'
 end


### PR DESCRIPTION
Here is a small patch to make em-synchrony work with the latest version of em-redis.
The specs were failing with version 0.3.0 and my modifications make them pass again. Does the changes seem valid to you ?
