### PR TITLE
Pending connection pool claims to be FIFO, but was actually FILO

### DIFF
--- a/lib/em-synchrony/connection_pool.rb
+++ b/lib/em-synchrony/connection_pool.rb
@@ -48,7 +48,7 @@ module EventMachine
         def release(fiber)
           @available.push(@reserved.delete(fiber.object_id))
 
-          if pending = @pending.pop
+          if pending = @pending.shift
             pending.resume
           end
         end


### PR DESCRIPTION
Under high concurrency, the pending connection pool was serving out the most recent requests first, instead of the oldest ones.  This caused the oldest requests to be filled last, instead of first.
