### PR TITLE
Mongo::Pool and MongoTimeoutHandler

### DIFF
--- a/lib/em-synchrony/mongo.rb
+++ b/lib/em-synchrony/mongo.rb
@@ -11,4 +11,22 @@ silence_warnings do
     Mutex = ::EventMachine::Synchrony::Thread::Mutex
     ConditionVariable = ::EventMachine::Synchrony::Thread::ConditionVariable
   end
+
+  class Mongo::Pool
+    TCPSocket = ::EventMachine::Synchrony::TCPSocket
+    Mutex = ::EventMachine::Synchrony::Thread::Mutex
+    ConditionVariable = ::EventMachine::Synchrony::Thread::ConditionVariable
+  end
+
+  class EventMachine::Synchrony::MongoTimeoutHandler
+    def self.timeout(op_timeout, ex_class, &block)
+      f = Fiber.current
+      timer = EM::Timer.new(op_timeout) { f.resume(nil) }
+      res = block.call
+      timer.cancel
+      res
+    end
+  end
+
+  Mongo::TimeoutHandler = EventMachine::Synchrony::MongoTimeoutHandler
 end


### PR DESCRIPTION
Recent versions of the Mongo driver implement a connection pool that em-sync isn't patching right now. This patches Mongo::Pool and also implements 'EventMachine::Synchrony::MongoTimeoutHandler' so that timeouts can work properly and failover to the new master in a replica set scenario rather than crashing the server process.
