### PR TITLE
Fixes double resume error on connection errors

### DIFF
--- a/lib/em-synchrony/em-http.rb
+++ b/lib/em-synchrony/em-http.rb
@@ -12,11 +12,15 @@ module EventMachine
          def #{type}(options = {}, &blk)
            f = Fiber.current
 
-            conn = setup_request(:#{type}, options, &blk)
-            conn.callback { f.resume(conn) }
-            conn.errback  { f.resume(conn) }
-
-            Fiber.yield
+           conn = setup_request(:#{type}, options, &blk)
+           if conn.error.nil?
+             conn.callback { f.resume(conn) }
+             conn.errback  { f.resume(conn) }
+             
+             Fiber.yield
+           else
+             conn
+           end
          end
       ]
     end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -1,6 +1,7 @@
 require "spec/helper/all"
 
 URL = "http://localhost:8081/"
+CONNECTION_ERROR_URL = "http://random-domain-blah.com/"
 DELAY = 0.25
 
 describe EventMachine::HttpRequest do
@@ -55,6 +56,15 @@ describe EventMachine::HttpRequest do
       res.responses[:errback].size.should == 0
 
       s.stop
+      EventMachine.stop
+    end
+  end
+  
+  it "should terminate immediately in case of connection errors" do
+    EventMachine.synchrony do
+      response = EventMachine::HttpRequest.new(CONNECTION_ERROR_URL).get
+      response.error.should_not be_nil
+      
       EventMachine.stop
     end
   end


### PR DESCRIPTION
Fixes double resume error on connection errors (for e.g. DNS resolve errors) in em-http-request. The spec fails without the patch attached.
