### PR TITLE
Add authentication to em-mongo

### DIFF
--- a/lib/em-synchrony/em-mongo.rb
+++ b/lib/em-synchrony/em-mongo.rb
@@ -9,7 +9,6 @@ module EM
 
     class Database
       def authenticate(username, password)
-        response = RequestResponse.new
         auth_result = self.collection(SYSTEM_COMMAND_COLLECTION).first({'getnonce' => 1})
 
         auth                 = BSON::OrderedHash.new
@@ -20,11 +19,10 @@ module EM
 
         auth_result2 = self.collection(SYSTEM_COMMAND_COLLECTION).first(auth)
         if EM::Mongo::Support.ok?(auth_result2)
-          response.succeed true
+          true
         else
-          response.fail auth_result2
+          raise AuthenticationError, auth_result2["errmsg"]
         end
-        response
       end
     end
 

--- a/spec/em-mongo_spec.rb
+++ b/spec/em-mongo_spec.rb
@@ -231,20 +231,29 @@ describe EM::Mongo do
     end
   end
 
-  it "authenticates" do
-    # For this to actually assert anything we will need to add the test user to
-    # the database
-    #
-    # From the Mongo shell:
-    # > use db
-    # > db.addUser('test', 'test')
-    EventMachine.synchrony do
-      database = EM::Mongo::Connection.new.db('db')
-      database.add_user('test', 'test')
-      auth = database.authenticate('test', 'test').callback do |cb|
-        cb.should == true
+  context "authentication" do
+    # these specs only get asserted if you run mongod with the --auth flag
+    it "successfully authenticates" do
+      # For this spec you will need to add this user to the database
+      #
+      # From the Mongo shell:
+      # > use db
+      # > db.addUser('test', 'test')
+      EventMachine.synchrony do
+        database = EM::Mongo::Connection.new.db('db')
+        database.authenticate('test', 'test').should == true
+        EventMachine.stop
       end
-      EventMachine.stop
+    end
+
+    it "raises an AuthenticationError if it cannot authenticate" do
+      EventMachine.synchrony do
+        database = EM::Mongo::Connection.new.db('db')
+        proc {
+          database.authenticate('test', 'wrong_password')
+        }.should raise_error(EventMachine::Mongo::AuthenticationError, "auth fails")
+        EventMachine.stop
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed in #63 the pullrequest. I've updated the authentication method so it does not return a callback anymore, instead the return value is directly usable.

I've also added two specs for succesfull authentication and one to check the correction exception. These tests only work if you run mongod with the --auth flag, otherwise they will always pass.
