### PR TITLE
fix nil callback issues when EM is not running

### DIFF
--- a/lib/em-synchrony/mysql2.rb
+++ b/lib/em-synchrony/mysql2.rb
@@ -24,6 +24,10 @@ module Mysql2
       def query(sql, opts={})
         deferable = aquery(sql, opts)
 
+        # if EM is not running, we just get the sql result directly
+        # if we get a deferable, then let's do the deferable thing.
+        return deferable unless deferable.kind_of? ::EM::DefaultDeferrable
+
         f = Fiber.current
         deferable.callback { |res| f.resume(res) }
         deferable.errback  { |err| f.resume(err) }


### PR DESCRIPTION
when EM is not running, the call to aquery returns the actual SQL result
instead of a Deferable object that we then need to wrap in fibery magic.
so, check what we get back.. if it's a deferable, wrap it.  if it's
anything else, just return that.

i think this helps address the issues in https://github.com/igrigorik/em-synchrony/issues/58

for me, the big litmus test is doing rails console and actually being able to load models etc.
