### PR TITLE
EM::Sync::TCPSocket could not be used in a ConnectionPool because it overrides #send

### DIFF
--- a/lib/em-synchrony/connection_pool.rb
+++ b/lib/em-synchrony/connection_pool.rb
@@ -65,7 +65,7 @@ module EventMachine
           async = (method[0,1] == "a")
 
           execute(async) do |conn|
-            df = conn.send(method, *args, &blk)
+            df = conn.__send__(method, *args, &blk)
 
             if async
               fiber = Fiber.current
@@ -75,6 +75,15 @@ module EventMachine
 
             df
           end
+        end
+
+        # Handle cases where the connection overrides #send
+        #
+        # Otherwise, our method_missing would proxy the
+        # wrong method call (the first argument) instead of proxying
+        # to connection#send
+        def send(*)
+          super
         end
     end
 

--- a/spec/tcpsocket_spec.rb
+++ b/spec/tcpsocket_spec.rb
@@ -17,4 +17,14 @@ describe EventMachine::Synchrony::TCPSocket  do
       EM.stop
     end
   end
+
+  it "should work when wrapped in a connection pool" do
+    EventMachine.synchrony do
+      @socket = EventMachine::Synchrony::ConnectionPool.new(size: 1) do
+        EventMachine::Synchrony::TCPSocket.new 'eventmachine.rubyforge.org', 80
+      end
+      @socket.send("PING").class.should be(Fixnum)
+      EM.stop
+    end
+  end
 end


### PR DESCRIPTION
- ConnectionPool now uses **send** to proxy calls via method_missing
  to handle cases where the connection overrides #send. It also defines
  #send itself and delegates to super to fully fix the above issue.
