### PR TITLE
EM::Synchrony::TCPSocket#closed? doesn't properly return false if connection is closed

### DIFF
--- a/lib/em-synchrony/tcpsocket.rb
+++ b/lib/em-synchrony/tcpsocket.rb
@@ -60,6 +60,7 @@ module EventMachine
       def unbind
         @in_req.fail  nil if @in_req
         @out_req.fail nil if @out_req
+        close
       end
 
       def receive_data(data)


### PR DESCRIPTION
I'm trying to debug a Dalli issue where the library doesn't properly reconnect to the memcached server if the connection is closed remotely. Since Dalli's socket class (<code>Dalli::Server::AsyncSocket</code>) inherits from <code>EM::Synchrony::TCPSocket</code>, I figured I could do a Dalli pull request call the <code>#closed?</code> method to properly detect whether the connection is closed or not. However, this doesn't work because on the <code>#unbind</code> hook, it doesn't unset the instance variables <code>@in_req</code> and <code>@out_req</code>, which is checked in <code>#closed?</code>.

While I'm not sure how you guys would do this exactly, I've gone ahead and changed the method to call the <code>#closed</code> method, since it'll unset the proper instance variables. I think it's OK to do this, since calling <code>#close_connection</code> after the fact shouldn't do anything.
