### PR TITLE
OPTIONS/PATCH support

### DIFF
--- a/lib/em-synchrony/em-http.rb
+++ b/lib/em-synchrony/em-http.rb
@@ -6,7 +6,7 @@ end
 
 module EventMachine
   module HTTPMethods
-     %w[get head post delete put].each do |type|
+     %w[get head post delete put patch options].each do |type|
        class_eval %[
          alias :a#{type} :#{type}
          def #{type}(options = {}, &blk)
@@ -16,7 +16,7 @@ module EventMachine
            if conn.error.nil?
              conn.callback { f.resume(conn) }
              conn.errback  { f.resume(conn) }
-             
+
              Fiber.yield
            else
              conn

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -28,9 +28,11 @@ describe EventMachine::HttpRequest do
       order.push :head if EventMachine::HttpRequest.new(URL).head
       order.push :post if EventMachine::HttpRequest.new(URL).delete
       order.push :put  if EventMachine::HttpRequest.new(URL).put
+      order.push :options if EventMachine::HttpRequest.new(URL).options
+      order.push :patch  if EventMachine::HttpRequest.new(URL).patch
 
       (now - start.to_f).should be_within(DELAY * order.size * 0.15).of(DELAY * order.size)
-      order.should == [:get, :post, :head, :post, :put]
+      order.should == [:get, :post, :head, :post, :put, :options, :patch]
 
       s.stop
       EventMachine.stop
@@ -49,10 +51,12 @@ describe EventMachine::HttpRequest do
       multi.add :c, EventMachine::HttpRequest.new(URL).ahead
       multi.add :d, EventMachine::HttpRequest.new(URL).adelete
       multi.add :e, EventMachine::HttpRequest.new(URL).aput
+      multi.add :f, EventMachine::HttpRequest.new(URL).aoptions
+      multi.add :g, EventMachine::HttpRequest.new(URL).apatch
       res = multi.perform
 
       (now - start.to_f).should be_within(DELAY * 0.15).of(DELAY)
-      res.responses[:callback].size.should == 5
+      res.responses[:callback].size.should == 7
       res.responses[:errback].size.should == 0
 
       s.stop


### PR DESCRIPTION
Was trying to play with a Goliath example using em-synchrony, proxying API requests, but found out that the OPTIONS and PATCH calls we sometimes make to our API would completely break. This seems to fix it.
