### PR TITLE
Improve TCPSocket read_nonblock & run TCP specs.

### DIFF
--- a/spec/helper/all.rb
+++ b/spec/helper/all.rb
@@ -1,9 +1,4 @@
-require 'rubygems'
-require 'rspec'
-require 'pp'
-
-require 'lib/em-synchrony'
-require 'lib/em-synchrony/em-http'
+require 'spec/helper/core'
 require 'lib/em-synchrony/mysql2'
 require 'lib/em-synchrony/em-remcached'
 require 'lib/em-synchrony/em-memcache'

--- a/spec/helper/core.rb
+++ b/spec/helper/core.rb
@@ -1,0 +1,6 @@
+require 'rubygems'
+require 'rspec'
+require 'pp'
+
+require 'lib/em-synchrony'
+require 'lib/em-synchrony/em-http'


### PR DESCRIPTION
The main fix: read_nonblock(x) is allowed to return < x bytes even before EOF
as documented in the ruby docs for IO#read_nonblock

Most TCPSocket specs were being ignored because of a Proc.new that wasn't
called.

Also takes the liberty of decoupling TCPSocket specs from the bigger
dependencies such as mysql2, amqp, etc.
