### PR TITLE
em-http-request is a dependency for em-synchrony

### DIFF
--- a/em-synchrony.gemspec
+++ b/em-synchrony.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "em-synchrony"
 
   s.add_runtime_dependency("eventmachine", ">= 1.0.0.beta.1")
+  s.add_dependency "em-http-request"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Without this, there is a runtime error generated while using "em-synchrony". Adding here would install "em-http-request" automatically.
