### PR TITLE
Fix broken AMQP driver code path

### DIFF
--- a/lib/em-synchrony/amqp.rb
+++ b/lib/em-synchrony/amqp.rb
@@ -54,7 +54,7 @@ module EventMachine
             def #{type}(name = 'amq.#{type}', opts = {})
               if exchange = find_exchange(name)
                 extended_opts = Exchange.add_default_options(:#{type}, name, opts, nil)
-                validate_parameters_match!(exchange, extended_opts)
+                validate_parameters_match!(exchange, extended_opts, :exchange)
                 exchange
               else
                 register_exchange(Exchange.new(self, :#{type}, name, opts))

--- a/spec/amqp_spec.rb
+++ b/spec/amqp_spec.rb
@@ -54,15 +54,13 @@ describe EM::Synchrony::AMQP do
       exchange = EM::Synchrony::AMQP::Exchange.new(channel, :fanout, "test.em-synchrony.exchange")
       exchange.should be_kind_of(EventMachine::Synchrony::AMQP::Exchange)
 
-      direct = channel.direct("test.em-synchrony.direct")
-      fanout = channel.fanout("test.em-synchrony.fanout")
-      topic = channel.topic("test.em-synchrony.topic")
-      headers = channel.headers("test.em-synchrony.headers")
+      [:direct, :fanout, :topic, :headers].each do |type|
+        # Exercise cached exchange code path
+        2.times.map { channel.send(type, "test.em-synchrony.#{type}") }.each do |ex|
+          ex.should be_kind_of(EventMachine::Synchrony::AMQP::Exchange)
+        end
+      end
 
-      direct.should be_kind_of(EventMachine::Synchrony::AMQP::Exchange)
-      fanout.should be_kind_of(EventMachine::Synchrony::AMQP::Exchange)
-      topic.should be_kind_of(EventMachine::Synchrony::AMQP::Exchange)
-      headers.should be_kind_of(EventMachine::Synchrony::AMQP::Exchange)
       EM.stop
     end
   end


### PR DESCRIPTION
This change set fixes a broken code path that manifests with the current AMQP gem (1.0.2). Commit: cf955e5.
The other 3 commits just remove some warnings and make code more readable.
