### PR TITLE
added 'pool_status' method

### DIFF
--- a/lib/em-synchrony/connection_pool.rb
+++ b/lib/em-synchrony/connection_pool.rb
@@ -27,6 +27,17 @@ module EventMachine
           release(f) if not async
         end
       end
+      
+      # Returns current pool utilization.
+      #
+      # @return [Hash] Current utilization.
+      def pool_status
+        {
+          available: @available.size,
+          reserved: @reserved.size,
+          pending: @pending.size
+        }
+      end
 
       private
 


### PR DESCRIPTION
Pull request for issue #170 . Method prefix is chosen to reduce likeliness of shadowing a method of the connection itself (e.g. `info` would have shadowed `Mysql2::EM::Client.info`).
