### PR TITLE
Adding hook to override Kernel.sleep behavior

### DIFF
--- a/lib/em-synchrony.rb
+++ b/lib/em-synchrony.rb
@@ -15,6 +15,7 @@ require "em-synchrony/tcpsocket"
 require "em-synchrony/connection_pool"
 require "em-synchrony/keyboard"
 require "em-synchrony/iterator"  if EventMachine::VERSION > '0.12.10'
+require "em-synchrony/kernel"
 
 module EventMachine
 
@@ -128,6 +129,15 @@ module EventMachine
       fiber = Fiber.current
       EM.system(cmd, *args){ |out, status| fiber.resume( [out, status] ) }
       Fiber.yield
+    end
+
+    # Overrides behavior of kernel.sleep
+    # Allows to add custom behavior, e.g. logging or redirection to
+    # EM::Synchrony.sleep .
+    # Calling 'sleep' in this function calls the actual kernel method.
+    #
+    def self.on_sleep(&blk)
+      Kernel.em_synchrony_sleep_hook = blk
     end
 
     # Routes to EM::Synchrony::Keyboard

--- a/lib/em-synchrony/kernel.rb
+++ b/lib/em-synchrony/kernel.rb
@@ -1,0 +1,27 @@
+# encoding: UTF-8
+require 'em-synchrony'
+
+# Monkey-patch
+module Kernel
+  alias_method :orig_sleep, :sleep
+
+  class << self
+    attr_accessor :em_synchrony_sleep_hook
+  end
+
+  # Monkey-patch
+  def sleep(sleep_time)
+    if Kernel.em_synchrony_sleep_hook &&
+       EM.reactor_thread? &&
+       !Thread.current[:em_synchrony_sleep_hook_called]
+      begin
+        Thread.current[:em_synchrony_sleep_hook_called] = true
+        Kernel.em_synchrony_sleep_hook.call(sleep_time)
+      ensure
+        Thread.current[:em_synchrony_sleep_hook_called] = false
+      end
+    else
+      orig_sleep(sleep_time)
+    end
+  end
+end

--- a/spec/kernel_override_spec.rb
+++ b/spec/kernel_override_spec.rb
@@ -1,0 +1,78 @@
+# encoding: UTF-8
+require 'spec/helper/all'
+
+describe EventMachine::Synchrony do
+  before do
+    EM::Synchrony.on_sleep
+  end
+  after do
+    EM::Synchrony.on_sleep
+  end
+  describe '#sleep' do
+    context 'outside synchrony' do
+      it 'does not call hook' do
+        EM::Synchrony.on_sleep { fail 'should not happen' }
+        expect { sleep(0.01) }.not_to raise_error
+      end
+      context 'with synchrony in another thread'do
+        before do
+          @thread = Thread.new do
+            EM.run do
+              sleep(0.5)
+              EM.stop
+            end
+          end
+          sleep(0.1)
+        end
+        after do
+          @thread.join
+        end
+        it 'does not call hook' do
+          EM::Synchrony.on_sleep { fail 'should not happen' }
+          expect { sleep(0.01) }.not_to raise_error
+        end
+      end
+    end
+
+    context 'within synchrony' do
+      around do |example|
+        EM.synchrony do
+          example.run
+          EM.next_tick { EM.stop }
+        end
+      end
+      context 'with no hook defined' do
+        it 'calls Kernel.sleep' do
+          expect(self).to receive(:sleep)
+          sleep(1)
+        end
+      end
+      context 'with hook defined' do
+        it 'executes the hook' do
+          called = 0
+          EM::Synchrony.on_sleep { called += 1 }
+          (1..10).each do |count|
+            sleep(1)
+            expect(called).to be count
+          end
+        end
+        it 'propagates exceptions' do
+          msg = 'expected exception'
+          EM::Synchrony.on_sleep { fail msg }
+          expect { sleep(1) }.to raise_error(RuntimeError, msg)
+        end
+        context "when calling 'sleep' in the hook" do
+          it 'calls the original sleep' do
+            sleep_time = 1.213234123412341454134512345
+            expect(self).to receive(:orig_sleep).with(sleep_time)
+            EM::Synchrony.on_sleep do |*args|
+              sleep(*args)
+            end
+            sleep(sleep_time)
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I recently ran into an issue where I used Resque::Plugins::Workers::Lock in an application with EM::Synchrony. That plugin is not fiber aware and calls Kernel.sleep in certain situations. Although I was able to fix this by monkey-patching that gem, I wondered how I can address this issue in a generic way or at least have some kind of information that I ran into a similar issue.

For that reason I created a hook in EM::Synchrony to specify what to do when sleep is called. Thereby I can specify that something is logged or even redirect the sleep to the EM::Synchrony version of it. 

I wonder whether this kind of functionality would be helpful.