### PR TITLE
fix compatibility with em-hiredis >= 0.2.1

### DIFF
--- a/lib/em-synchrony/em-hiredis.rb
+++ b/lib/em-synchrony/em-hiredis.rb
@@ -13,6 +13,16 @@ module EventMachine
       client
     end
     
+    class Client
+      def pubsub
+        return @pubsub if @pubsub
+
+        client = PubsubClient.new(@host, @port, @password, @db)
+        EM::Synchrony.sync client.connect
+        @pubsub = client
+      end
+    end
+    
     class BaseClient
       def self.connect(host = 'localhost', port = 6379)
         conn = new(host, port)


### PR DESCRIPTION
To get em-synchrony working with latest em-hiredis including commit https://github.com/mloughran/em-hiredis/commit/4b7ec0273790cfe491d686b97894e04297d07c64 you need this patch. It seems to work with my app and pass spec test, but it may contain bugs
