### PR TITLE
Abillity to Interrupt current fiber to give chance to other fibers

### DIFF
--- a/lib/em-synchrony.rb
+++ b/lib/em-synchrony.rb
@@ -135,5 +135,13 @@ module EventMachine
     def self.gets
       EventMachine::Synchrony::Keyboard.new.gets
     end
+
+    # Interrupt current fiber to give chance to other fibers
+    #
+    def self.interrupt
+      fiber = Fiber.current
+      EM.next_tick { fiber.resume }
+      Fiber.yield
+    end
   end
 end


### PR DESCRIPTION
Usage example.

```
class WebsocketApiClient
  def connect
    # start websocket connection
    # setup incoming connection handler
  end

  def on_incoming_event(data)
    @events ||= []
    @events << data
  end

  def events
    EM::Synchrony.interrupt
    @events
  end
end

EM.synchrony do
  c = WebsocketApiClient.new
  c.connect
  puts c.events
  EM.stop
end
```
