### PR TITLE
multi succeeds twice bug

### DIFF
--- a/lib/em-synchrony/em-multi.rb
+++ b/lib/em-synchrony/em-multi.rb
@@ -13,11 +13,11 @@ module EventMachine
       def add(name, conn)
         raise 'Duplicate Multi key' if @requests.key? name
 
+        @requests[name] = conn
+
         fiber = Fiber.current
         conn.callback { @responses[:callback][name] = conn; check_progress(fiber) }
         conn.errback  { @responses[:errback][name]  = conn; check_progress(fiber) }
-
-        @requests[name] = conn
       end
 
       def finished?

--- a/spec/multi_spec.rb
+++ b/spec/multi_spec.rb
@@ -9,5 +9,21 @@ describe EM::Synchrony do
         m.add :df1, EM::DefaultDeferrable.new
       end.should raise_error("Duplicate Multi key")
     end
+
+    context "when defferable succeeded before adding" do
+      it "does not succeed twice" do
+        multi = EM::Synchrony::Multi.new
+        multi.should_receive(:succeed).once
+
+        slow = EM::DefaultDeferrable.new
+        multi.add :slow, slow
+
+        quick = EM::DefaultDeferrable.new
+        quick.succeed
+        multi.add :quick, quick
+
+        slow.succeed
+      end
+    end
   end
 end


### PR DESCRIPTION
Multi succeeds twice if request is performed before adding. For example, when defferable object has cache, it may get data without making remote request. In this case, callback body is called earlier than connection is added to @requests hash. 

em-http-request contains logic without this bug. See https://github.com/igrigorik/em-http-request/blob/master/lib/em-http/multi.rb