### PR TITLE
Fiber aware support for ActiveRecord 4

### DIFF
--- a/lib/em-synchrony.rb
+++ b/lib/em-synchrony.rb
@@ -10,6 +10,7 @@ end
 
 require "em-synchrony/core_ext"
 require "em-synchrony/thread"
+require "em-synchrony/monitor_mixin"
 require "em-synchrony/em-multi"
 require "em-synchrony/tcpsocket"
 require "em-synchrony/connection_pool"

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -8,12 +8,42 @@ ActiveSupport.on_load(:active_record) do
       ActiveRecord::Base.connection_id ||= Fiber.current.object_id
     end
 
-    def clear_stale_cached_connections!
-      []
+    if ActiveRecord::VERSION::MAJOR == 3
+      # on AR 4.0 `clear_stale_cached_connections!` is marked as deprecated and just calls `reap`
+      # `reap` on AR 4.x is implemented well and there is no reason to stub it
+      # on AR >= 4.1 there is no `clear_stale_cached_connections!`
+      def clear_stale_cached_connections!
+        []
+      end
+    end
+
+    if ActiveRecord::VERSION::MAJOR == 4
+      # on AR 4.x if `reaping_frequency` option used, it should work correctly
+      class Reaper
+        def run
+          return unless frequency
+          EM::Synchrony.add_periodic_timer(frequency) do
+            pool.reap
+          end
+        end
+      end
     end
   end
 
   class ActiveRecord::ConnectionAdapters::AbstractAdapter
     include EventMachine::Synchrony::MonitorMixin
+
+    if ActiveRecord::VERSION::MAJOR == 4
+      if ActiveRecord::VERSION::MINOR == 2
+        # on AR 4.2 `lease` sets @owner to Thread.current so we should implement it fiber aware
+        def lease
+          synchronize do
+            unless in_use?
+              @owner = Fiber.current
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -4,6 +4,7 @@ require 'em-synchrony'
 ActiveSupport.on_load(:active_record) do
   class ActiveRecord::ConnectionAdapters::ConnectionPool
     include EventMachine::Synchrony::MonitorMixin
+    Monitor = EventMachine::Synchrony::Monitor
 
     def current_connection_id #:nodoc:
       ActiveRecord::Base.connection_id ||= Fiber.current.object_id

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'em-synchrony'
 
 ActiveSupport.on_load(:active_record) do

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -1,144 +1,19 @@
 require 'em-synchrony'
-require 'active_record'
-require 'active_record/connection_adapters/abstract/connection_pool'
-require 'active_record/connection_adapters/abstract_adapter'
-require 'em-synchrony/thread'
 
-module ActiveRecord
-  module ConnectionAdapters
-    class ConnectionPool
-      def connection
-        _fibered_mutex.synchronize do
-          @reserved_connections[current_connection_id] ||= checkout
-        end
-      end
+ActiveSupport.on_load(:active_record) do
+  class ActiveRecord::ConnectionAdapters::ConnectionPool
+    include EventMachine::Synchrony::MonitorMixin
 
-      def _fibered_mutex
-        @fibered_mutex ||= EM::Synchrony::Thread::Mutex.new
-      end
+    def current_connection_id #:nodoc:
+      ActiveRecord::Base.connection_id ||= Fiber.current.object_id
+    end
+
+    def clear_stale_cached_connections!
+      []
     end
   end
-end
 
-module EM::Synchrony
-  module ActiveRecord
-    module Client
-      def open_transactions
-        @open_transactions ||= 0
-      end
-
-      def open_transactions=(v)
-        @open_transactions = v
-      end
-
-      def acquired_for_connection_pool
-        @acquired_for_connection_pool ||= 0
-      end
-
-      def acquired_for_connection_pool=(v)
-        @acquired_for_connection_pool = v
-      end
-    end
-    
-    module Adapter
-      def configure_connection
-        nil
-      end
-
-      def transaction(*args, &blk)
-        @connection.execute(false) do |conn|
-          super
-        end
-      end
-
-      def real_connection
-        @connection.connection
-      end
-
-      def open_transactions
-        real_connection.open_transactions
-      end
-
-      def increment_open_transactions
-        real_connection.open_transactions += 1
-      end
-
-      def decrement_open_transactions
-        real_connection.open_transactions -= 1
-      end
-
-      def current_transaction #:nodoc:
-        @transaction[Fiber.current.object_id] || @closed_transaction
-      end
-
-      def transaction_open?
-        current_transaction.open?
-      end
-
-      def begin_transaction(options = {}) #:nodoc:
-        set_current_transaction(current_transaction.begin(options))
-      end
-
-      def commit_transaction #:nodoc:
-        set_current_transaction(current_transaction.commit)
-      end
-
-      def rollback_transaction #:nodoc:
-        set_current_transaction(current_transaction.rollback)
-      end
-
-      def reset_transaction #:nodoc:
-        @transaction = {}
-        @closed_transaction = ::ActiveRecord::ConnectionAdapters::ClosedTransaction.new(self)
-      end
-
-      # Register a record with the current transaction so that its after_commit and after_rollback callbacks
-      # can be called.
-      def add_transaction_record(record)
-        current_transaction.add_record(record)
-      end
-
-      protected
-
-      def set_current_transaction(t)
-        if t == @closed_transaction
-          @transaction.delete(Fiber.current.object_id)
-        else
-          @transaction[Fiber.current.object_id] = t
-        end
-      end
-    end
-
-    class ConnectionPool < EM::Synchrony::ConnectionPool
-
-      # consider connection acquired
-      def execute(async)
-        f = Fiber.current
-        begin
-          conn = acquire(f)
-          conn.acquired_for_connection_pool += 1
-          yield conn
-        ensure
-          conn.acquired_for_connection_pool -= 1
-          release(f) if !async && conn.acquired_for_connection_pool == 0
-        end
-      end
-
-      def acquire(fiber)
-        return @reserved[fiber.object_id] if @reserved[fiber.object_id]
-        super
-      end
-
-      def connection
-        acquire(Fiber.current)
-      end
-
-      # via method_missing affected_rows will be recognized as async method
-      def affected_rows(*args, &blk)
-        execute(false) do |conn|
-          conn.send(:affected_rows, *args, &blk)
-        end
-      end
-    end
+  class ActiveRecord::ConnectionAdapters::AbstractAdapter
+    include EventMachine::Synchrony::MonitorMixin
   end
 end

--- a/lib/em-synchrony/monitor_mixin.rb
+++ b/lib/em-synchrony/monitor_mixin.rb
@@ -1,0 +1,125 @@
+require 'em-synchrony/thread'
+
+module EventMachine
+  module Synchrony
+
+    # Fiber-aware drop-in replacements for MonitorMixin
+    module MonitorMixin
+      class ConditionVariable < ::MonitorMixin::ConditionVariable
+        private
+
+        def initialize(monitor)
+          @monitor = monitor
+          @cond = EventMachine::Synchrony::Thread::ConditionVariable.new
+        end
+      end
+
+      def self.extend_object(obj)
+        super(obj)
+        obj.__send__(:mon_initialize)
+      end
+
+
+      #
+      # Attempts to enter exclusive section.  Returns +false+ if lock fails.
+      #
+      def mon_try_enter
+        if @mon_owner != Fiber.current
+          unless @mon_mutex.try_lock
+            return false
+          end
+          @mon_owner = Fiber.current
+        end
+        @mon_count += 1
+        return true
+      end
+      # For backward compatibility
+      alias try_mon_enter mon_try_enter
+
+      #
+      # Enters exclusive section.
+      #
+      def mon_enter
+        if @mon_owner != Fiber.current
+          @mon_mutex.lock
+          @mon_owner = Fiber.current
+        end
+        @mon_count += 1
+      end
+
+      #
+      # Leaves exclusive section.
+      #
+      def mon_exit
+        mon_check_owner
+        @mon_count -=1
+        if @mon_count == 0
+          @mon_owner = nil
+          @mon_mutex.unlock
+        end
+      end
+
+      #
+      # Enters exclusive section and executes the block.  Leaves the exclusive
+      # section automatically when the block exits.  See example under
+      # +MonitorMixin+.
+      #
+      def mon_synchronize
+        mon_enter
+        begin
+          yield
+        ensure
+          mon_exit
+        end
+      end
+      alias synchronize mon_synchronize
+
+      #
+      # Creates a new Synchrony::MonitorMixin::ConditionVariable associated with the
+      # receiver.
+      #
+      def new_cond
+        return ConditionVariable.new(self)
+      end
+
+      private
+
+      def initialize(*args)
+        super
+        mon_initialize
+      end
+
+      def mon_initialize
+        @mon_owner = nil
+        @mon_count = 0
+        @mon_mutex = EventMachine::Synchrony::Thread::Mutex.new
+      end
+
+      def mon_check_owner
+        if @mon_owner != Fiber.current
+          raise FiberError, "current fiber not owner"
+        end
+      end
+
+      def mon_enter_for_cond(count)
+        @mon_owner = Fiber.current
+        @mon_count = count
+      end
+
+      def mon_exit_for_cond
+        count = @mon_count
+        @mon_owner = nil
+        @mon_count = 0
+        return count
+      end
+    end
+
+    # Fiber-aware drop-in replacements for Monitor
+    class Monitor
+      include MonitorMixin
+      alias try_enter try_mon_enter
+      alias enter mon_enter
+      alias exit mon_exit
+    end
+  end
+end

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -24,6 +24,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
         :pool => 10
       )
       Widget.delete_all
+      Widget.clear_active_connections!
   end
 
   it "should establish AR connection" do
@@ -59,6 +60,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
       EM::Synchrony::FiberIterator.new(1..100, 40).each do |i|
         widget = Widget.create title: 'hi'
         widget.update_attributes title: 'hello'
+        Widget.clear_active_connections!
       end
       EM.stop
     end
@@ -97,6 +99,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
           ActiveRecord::Base.transaction do
             raise ActiveRecord::Rollback
           end
+          Widget.clear_active_connections!
         end
         Widget.all.each do |widget|
           widget.title.should eq('hello')

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -116,7 +116,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
             :database => 'widgets',
             :username => 'root',
             :reaping_frequency => DELAY,
-            :dead_connection_timeout => DELAY,
+            :dead_connection_timeout => DELAY * 2,
             :pool => 2
           )
 

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -115,8 +115,8 @@ describe "Fiberized ActiveRecord driver for mysql2" do
             :adapter => 'em_mysql2',
             :database => 'widgets',
             :username => 'root',
-            :reaping_frequency => DELAY,
-            :dead_connection_timeout => DELAY * 2,
+            :reaping_frequency => DELAY * 2,
+            :dead_connection_timeout => DELAY,
             :pool => 2
           )
 

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -104,7 +104,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
   end
 
   describe "ActiveRecord 4" do
-    before(:all) do
+    before do
       skip if ActiveRecord::VERSION::MAJOR != 4
     end
 


### PR DESCRIPTION
Hello!
I took https://github.com/igrigorik/em-synchrony/pull/179 and added support for ActiveRecord 4.
All ActiveRecord specs are green for stable versions of 3.2, 4.0, 4.1 and 4.2.

Also I reimplemented `clear_stale_cached_connections!` for 3.2 that could help but not so much. ActiveRecord users should explicitly release connections or `ActiveRecord::ConnectionAdapters::ConnectionManagement` middleware could do this and there is nothing to do with it. By the way, they should do it in threaded environment too. Anyway.

3.1 is not working and I cannot figure out why. So my opinion: we should drop 3.1 support in favor of better implementation for >= 3.2, < 5.

Currently tests may fail because of broken `mysql2`. See https://github.com/brianmario/mysql2/pull/580 (with specs) or https://github.com/brianmario/mysql2/pull/509 — with any of these patches everything works great.
