### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
 services:
   - mysql
   - rabbitmq
+  - mongodb
+  - memcached
+  - redis-server
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: ruby
+
 rvm:
   - 1.9.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
 
 services:
   - mysql
+  - rabbitmq
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 
 matrix:
   include:
-    - script: "bundle exec rspec"
     - env: "activerecord=3.2.21"
       script: "bundle exec rspec spec/activerecord_spec.rb"
     - env: "activerecord=4.0.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 rvm:
   - 1.9.3
 
+sudo: false
+
 services:
   - mysql
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+rvm:
+  - 1.9.3
+
+services:
+  - mysql
+
+matrix:
+  include:
+    - script: "bundle exec rspec"
+    - env: "activerecord=3.2.21"
+      script: "bundle exec rspec spec/activerecord_spec.rb"
+    - env: "activerecord=4.0.9"
+      script: "bundle exec rspec spec/activerecord_spec.rb"
+    - env: "activerecord=4.2.0"
+      script: "bundle exec rspec spec/activerecord_spec.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ matrix:
       script: "bundle exec rspec spec/activerecord_spec.rb"
     - env: "activerecord=4.2.0"
       script: "bundle exec rspec spec/activerecord_spec.rb"
+  allow_failures:
+    - env: "activerecord=3.2.21"
+    - env: "activerecord=4.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ services:
   - memcached
   - redis-server
 
+before_script:
+  - mysql < spec/widgets.sql
+
 matrix:
   include:
     - env: "activerecord=3.2.21"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'eventmachine', :git => 'git://github.com/eventmachine/eventmachine.git'
 
 group :development do
   gem 'rake'
-  gem 'rspec'
+  gem 'rspec', '~> 3.2'
   gem 'em-http-request', :git => 'git://github.com/igrigorik/em-http-request'
   gem 'remcached'
   # gem 'em-mongo', :git => 'https://github.com/bcg/em-mongo.git'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 gem 'eventmachine', :git => 'git://github.com/eventmachine/eventmachine.git'
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem 'em-http-request', :git => 'git://github.com/igrigorik/em-http-request'
   gem 'remcached'
   # gem 'em-mongo', :git => 'https://github.com/bcg/em-mongo.git'
-  gem 'activerecord', '= 4.1.8'
+  gem 'activerecord', "= #{ENV['activerecord'] || '4.1.8'}"
   gem 'em-mongo'
   gem 'bson_ext'
   gem 'mysql2'

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -2,13 +2,7 @@ require "spec/helper/all"
 require "em-synchrony/activerecord"
 require "em-synchrony/fiber_iterator"
 
-# create database widgets;
-# use widgets;
-# create table widgets (
-# id INT NOT NULL AUTO_INCREMENT,
-# title varchar(255),
-# PRIMARY KEY (`id`)
-# );
+# mysql < spec/widgets.sql
 
 class Widget < ActiveRecord::Base; end;
 

--- a/spec/amqp_spec.rb
+++ b/spec/amqp_spec.rb
@@ -14,7 +14,7 @@ describe EM::Synchrony::AMQP do
     EM.synchrony do
       connection = EM::Synchrony::AMQP.connect
       connection.disconnect
-      connection.connected?.should be_false
+      connection.connected?.should eq(false)
       EM.stop
     end
   end

--- a/spec/amqp_spec.rb
+++ b/spec/amqp_spec.rb
@@ -5,7 +5,7 @@ describe EM::Synchrony::AMQP do
   it "should yield until connection is ready" do
     EM.synchrony do
       connection = EM::Synchrony::AMQP.connect
-      connection.connected?.should be_true
+      connection.connected?.should eq(true)
       EM.stop
     end
   end

--- a/spec/em-mongo_spec.rb
+++ b/spec/em-mongo_spec.rb
@@ -4,10 +4,10 @@ describe EM::Mongo do
   it "should yield until connection is ready" do
     EventMachine.synchrony do
       connection = EM::Mongo::Connection.new
-      connection.connected?.should be_true
+      connection.connected?.should eq(true)
 
       db = connection.db('db')
-      db.is_a?(EventMachine::Mongo::Database).should be_true
+      db.is_a?(EventMachine::Mongo::Database).should eq(true)
 
       EventMachine.stop
     end
@@ -45,7 +45,7 @@ describe EM::Mongo do
         obj2.size.should == 1
 
         obj3 = collection.first
-        obj3.is_a?(Hash).should be_true
+        obj3.is_a?(Hash).should eq(true)
 
         EventMachine.stop
       end
@@ -114,7 +114,7 @@ describe EM::Mongo do
             obj2.size.should == 1
           end
           collection.afirst.callback do |obj3|
-            obj3.is_a?(Hash).should be_true
+            obj3.is_a?(Hash).should eq(true)
             obj3['hello'].should == 'world'
             EM.next_tick{ EventMachine.stop }
           end
@@ -181,7 +181,7 @@ describe EM::Mongo do
             obj2.size.should == 1
           end
           collection.afirst do |obj3|
-            obj3.is_a?(Hash).should be_true
+            obj3.is_a?(Hash).should eq(true)
             obj3['hello'].should == 'world'
             EM.next_tick{ EventMachine.stop }
           end

--- a/spec/em-mongo_spec.rb
+++ b/spec/em-mongo_spec.rb
@@ -233,7 +233,7 @@ describe EM::Mongo do
 
   context "authentication" do
     # these specs only get asserted if you run mongod with the --auth flag
-    it "successfully authenticates" do
+    it "successfully authenticates", ci_skip: true do
       # For this spec you will need to add this user to the database
       #
       # From the Mongo shell:

--- a/spec/helper/all.rb
+++ b/spec/helper/all.rb
@@ -14,4 +14,6 @@ def now(); Time.now.to_f; end
 
 RSpec.configure do |config|
   config.include(Sander6::CustomMatchers)
+
+  config.filter_run_excluding ci_skip: true if ENV['CI']
 end

--- a/spec/hiredis_spec.rb
+++ b/spec/hiredis_spec.rb
@@ -5,7 +5,7 @@ describe EM::Hiredis do
   it "should yield until connection is ready" do
     EventMachine.synchrony do
       connection = EM::Hiredis::Client.connect
-      connection.connected.should be_true
+      connection.connected.should eq(true)
 
       EventMachine.stop
     end

--- a/spec/hiredis_spec.rb
+++ b/spec/hiredis_spec.rb
@@ -2,10 +2,13 @@ require "spec/helper/all"
 
 describe EM::Hiredis do
 
-  it "should yield until connection is ready" do
+  it "should connect on demand" do
     EventMachine.synchrony do
       connection = EM::Hiredis::Client.connect
-      connection.connected.should eq(true)
+      connection.should_not be_connected
+
+      connection.ping
+      connection.should be_connected
 
       EventMachine.stop
     end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -5,7 +5,7 @@ describe EM::Protocols::Redis do
   it "should yield until connection is ready" do
     EventMachine.synchrony do
       connection = EM::Protocols::Redis.connect
-      connection.connected.should be_true
+      connection.connected.should eq(true)
 
       EventMachine.stop
     end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -90,7 +90,7 @@ describe EM::Protocols::Redis do
     end
   end
 
-  it "should execute sync add and auth" do
+  it "should execute sync add and auth", ci_skip: true do
     EventMachine.synchrony do
       redis = EM::Protocols::Redis.connect
       redis.auth('abc')

--- a/spec/remcached_spec.rb
+++ b/spec/remcached_spec.rb
@@ -28,9 +28,9 @@ describe Memcached do
   end
 
   it "should fire multi memcached requests" do
-    EventMachine.synchrony do
-      pending "patch mult-get"
+    skip "patch mult-get"
 
+    EventMachine.synchrony do
       Memcached.connect %w(localhost)
       Memcached.multi_get([{:key => 'foo'},{:key => 'bar'}, {:key => 'test'}]) do |res|
         # TODO

--- a/spec/remcached_spec.rb
+++ b/spec/remcached_spec.rb
@@ -6,7 +6,7 @@ describe Memcached do
   it "should yield until connection is ready" do
     EventMachine.synchrony do
       Memcached.connect %w(localhost)
-      Memcached.usable?.should be_true
+      Memcached.usable?.should eq(true)
       EventMachine.stop
     end
   end

--- a/spec/synchrony_spec.rb
+++ b/spec/synchrony_spec.rb
@@ -19,14 +19,23 @@ describe EM::Synchrony do
 
   describe "#next_tick" do
     it "should wrap next_tick into a Fiber context" do
-      Fiber.new {
-        df = EM::DefaultDeferrable.new
+      EM.synchrony {
+        begin
+          fired = false
+          f = Fiber.current
 
-        EM::Synchrony.next_tick do
-          df.succeed args
-          EM::Synchrony.sync(df).should == args
+          EM::Synchrony.next_tick do
+            fired = true
+            Fiber.current.should_not eq(f)
+          end
+
+          EM::Synchrony.interrupt
+
+          fired.should eq(true)
+        ensure
+          EM.stop
         end
-      }.resume
+      }
     end
   end
 

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -2,7 +2,7 @@ require "spec/helper/all"
 
 describe EventMachine::Synchrony do
 
-  it "system: simple" do
+  it "system: simple", ci_skip: true do
     EM.synchrony do
       out, status = EM::Synchrony.system("echo 'some'")
       

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -2,9 +2,7 @@ require "spec/helper/all"
 
 describe EventMachine::Synchrony do
 
-  # FIXME: Not only it fails on Travis for some reason, but it also
-  # triggers failures in many of the examples that run after it.
-  it "system: simple", ci_skip: true do
+  it "system: simple" do
     EM.synchrony do
       out, status = EM::Synchrony.system("echo 'some'")
 

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -2,16 +2,16 @@ require "spec/helper/all"
 
 describe EventMachine::Synchrony do
 
+  # FIXME: Not only it fails on Travis for some reason, but it also
+  # triggers failures in many of the examples that run after it.
   it "system: simple", ci_skip: true do
     EM.synchrony do
       out, status = EM::Synchrony.system("echo 'some'")
-      
+
       status.should == 0
       out.should == "some\n"
-      
-      EM.stop    
+
+      EM.stop
     end
   end
-  
-  
 end

--- a/spec/widgets.sql
+++ b/spec/widgets.sql
@@ -1,0 +1,9 @@
+create database widgets;
+
+use widgets;
+
+create table widgets (
+  id INT NOT NULL AUTO_INCREMENT,
+  title varchar(255),
+  PRIMARY KEY (`id`)
+);


### PR DESCRIPTION
This adds `.travis.yml`, fixes some broken specs and updates the outdated specs to work in RSpec 3.2 (which is what its Gemfile entry without specific version asks for).

The main motivation is for everyone to be able to see the state of affairs WRT ActiveRecord versions compatibility, and to run every pull request purported to fix it against multiple AR versions. See the current build results here:

https://travis-ci.org/dgutov/em-synchrony/builds/54472508