### PR TITLE
Real concurrency spec for ActiveRecord

### DIFF
--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -16,10 +16,6 @@ module ActiveRecord
       def _fibered_mutex
         @fibered_mutex ||= EM::Synchrony::Thread::Mutex.new
       end
-
-      def current_connection_id
-        ActiveRecord::Base.connection_id ||= Fiber.current.object_id
-      end
     end
   end
 end

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -16,6 +16,10 @@ module ActiveRecord
       def _fibered_mutex
         @fibered_mutex ||= EM::Synchrony::Thread::Mutex.new
       end
+
+      def current_connection_id
+        ActiveRecord::Base.connection_id ||= Fiber.current.object_id
+      end
     end
   end
 end

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -60,12 +60,14 @@ describe "Fiberized ActiveRecord driver for mysql2" do
 
   it "should effectively use pool in high concurrency" do
     EM.synchrony do
+      require 'active_record/connection_adapters/em_mysql2_adapter'
+      expect(ActiveRecord::ConnectionAdapters::EMMysql2Adapter::Client).to receive(:new).exactly(11).times.and_call_original
       establish_connection
       EM::Synchrony::FiberIterator.new(1..100, 40).each do |i|
         widget = Widget.create title: 'hi'
         widget.update_attributes title: 'hello'
       end
-      expect(Widget.connection_pool.connections.size).to eq(10)
+      # expect(Widget.connection_pool.connections.size).to eq(10)
       EM.stop
     end
   end

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -58,6 +58,18 @@ describe "Fiberized ActiveRecord driver for mysql2" do
     end
   end
 
+  it "should effectively use pool in high concurrency" do
+    EM.synchrony do
+      establish_connection
+      EM::Synchrony::FiberIterator.new(1..100, 40).each do |i|
+        widget = Widget.create title: 'hi'
+        widget.update_attributes title: 'hello'
+      end
+      expect(Widget.connection_pool.connections.size).to eq(10)
+      EM.stop
+    end
+  end
+
   it "should create widget" do
     EM.synchrony do
       establish_connection

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -61,7 +61,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
   it "should effectively use pool in high concurrency" do
     EM.synchrony do
       require 'active_record/connection_adapters/em_mysql2_adapter'
-      expect(ActiveRecord::ConnectionAdapters::EMMysql2Adapter::Client).to receive(:new).exactly(11).times.and_call_original
+      expect(ActiveRecord::ConnectionAdapters::EMMysql2Adapter::Client).to receive(:new).exactly(10).times.and_call_original
       establish_connection
       EM::Synchrony::FiberIterator.new(1..100, 40).each do |i|
         widget = Widget.create title: 'hi'


### PR DESCRIPTION
This one should fail. It should prove that current implementation is not actually concurrent. It ignores `:pool` ActiveRecord parameter making ConnectionPool useless.