### PR TITLE
Add new adapter for ActiveRecord 4.2, fix #198

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem 'activerecord', "= #{ENV['activerecord'] || '4.1.8'}"
   gem 'em-mongo'
   gem 'bson_ext'
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.18'
   gem 'em-redis', '~> 0.3.0'
   gem 'em-hiredis'
   gem 'mongo'

--- a/lib/active_record/connection_adapters/em_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/em_mysql2_adapter.rb
@@ -41,7 +41,12 @@ module ActiveRecord
         include EM::Synchrony::ActiveRecord::Client
       end
 
-      include EM::Synchrony::ActiveRecord::Adapter
+      if ::ActiveRecord.version >= Gem::Version.new('4.2')
+        require 'em-synchrony/activerecord_4_2'
+        include EM::Synchrony::ActiveRecord::Adapter_4_2
+      else
+        include EM::Synchrony::ActiveRecord::Adapter
+      end
     end
   end
 end

--- a/lib/em-synchrony/activerecord_4_2.rb
+++ b/lib/em-synchrony/activerecord_4_2.rb
@@ -21,7 +21,7 @@ module EM::Synchrony
     class TransactionManager < ::ActiveRecord::ConnectionAdapters::TransactionManager
       def initialize(*args)
         super
-        @stack = Hash.new([])
+        @stack = Hash.new { |h, k| h[k] = [] }
       end
 
       def current_transaction #:nodoc:

--- a/lib/em-synchrony/activerecord_4_2.rb
+++ b/lib/em-synchrony/activerecord_4_2.rb
@@ -1,0 +1,61 @@
+require 'active_record'
+
+module EM::Synchrony
+  module ActiveRecord
+    module Adapter_4_2
+      def configure_connection
+        nil
+      end
+
+      def transaction(*args)
+        @connection.execute(false) do |conn|
+          super
+        end
+      end
+
+      def reset_transaction #:nodoc:
+        @transaction_manager = TransactionManager.new(self)
+      end
+    end
+
+    class TransactionManager < ::ActiveRecord::ConnectionAdapters::TransactionManager
+      def initialize(*args)
+        super
+        @stack = Hash.new([])
+      end
+
+      def current_transaction #:nodoc:
+        _current_stack.last || NULL_TRANSACTION
+      end
+
+      def open_transactions
+        _current_stack.size
+      end
+
+      def begin_transaction(options = {}) #:nodoc:
+        transaction =
+          if _current_stack.empty?
+            ::ActiveRecord::ConnectionAdapters::RealTransaction.new(@connection, options)
+          else
+            ::ActiveRecord::ConnectionAdapters::SavepointTransaction.new(@connection, "active_record_#{Fiber.current.object_id}_#{open_transactions}", options)
+          end
+        _current_stack.push(transaction)
+        transaction
+      end
+
+      def commit_transaction #:nodoc:
+        _current_stack.pop.commit
+      end
+
+      def rollback_transaction #:nodoc:
+        _current_stack.pop.rollback
+      end
+
+      private
+
+      def _current_stack
+        @stack[Fiber.current.object_id]
+      end
+    end
+  end
+end

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -9,15 +9,24 @@ class Widget < ActiveRecord::Base; end;
 describe "Fiberized ActiveRecord driver for mysql2" do
   DELAY = 0.25
   QUERY = "SELECT sleep(#{DELAY})"
+  LOGGER = Logger.new(STDOUT).tap do |logger|
+    logger.formatter = proc do |_severity, datetime, _progname, msg|
+      "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')} ##{Fiber.current.object_id}] -- : #{msg}\n"
+    end
+  end
+
+  before(:all) do
+    ActiveRecord::Base.logger = LOGGER if ENV['LOGGER']
+  end
 
   def establish_connection
-      ActiveRecord::Base.establish_connection(
-        :adapter => 'em_mysql2',
-        :database => 'widgets',
-        :username => 'root',
-        :pool => 10
-      )
-      Widget.delete_all
+    ActiveRecord::Base.establish_connection(
+      :adapter => 'em_mysql2',
+      :database => 'widgets',
+      :username => 'root',
+      :pool => 10
+    )
+    Widget.delete_all
   end
 
   it "should establish AR connection" do

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -98,6 +98,7 @@ describe "Fiberized ActiveRecord driver for mysql2" do
             widget.update_attributes title: "hello"
           end
           ActiveRecord::Base.transaction do
+            widget.update_attributes(title: 'hey')
             raise ActiveRecord::Rollback
           end
         end


### PR DESCRIPTION
Yet another try to add support for ActiveRecord 4.2 and fix #198. 
It just adds a new adapter by replacing `ClosedTransaction` with `NullTransaction` and using `ActiveRecord::ConnectionAdapters::TransactionManager`. Generally it keeps the same behavior.

There is also another PR #190 which changes `MonitorMixin` to add fiber aware support.