### PR TITLE
Fix passing nested arrays to FIberIterator with iter

### DIFF
--- a/lib/em-synchrony/fiber_iterator.rb
+++ b/lib/em-synchrony/fiber_iterator.rb
@@ -7,7 +7,7 @@ module EventMachine
       # and auto-advance the iterator after each call
       def each(foreach=nil, after=nil, &blk)
         fe = Proc.new do |obj, iter|
-          Fiber.new { (foreach || blk).call(obj); iter.next }.resume
+          Fiber.new { (foreach || blk).call(obj, iter); iter.next }.resume
         end
 
         super(fe, after)

--- a/spec/fiber_iterator_spec.rb
+++ b/spec/fiber_iterator_spec.rb
@@ -18,6 +18,19 @@ describe EventMachine::Synchrony::FiberIterator do
     end
   end
 
+  it "works even with nested arrays and iterator" do
+    EM.synchrony do
+      results = []
+      list = [[1, 2], [3, 4]]
+
+      EM::Synchrony::FiberIterator.new(list, 2).each { |sublist, iter| results.push(sublist) }
+
+      expect(results).to eq(list)
+
+      EM.stop
+    end
+  end
+
   #
   # it "should sum values within the iterator" do
   #   EM.synchrony do


### PR DESCRIPTION
Hi,

When I try to use `FiberIterator` for nested arrays and pass `iter` argument to block, it iterates only through the first elements of each nested array.

```ruby
EM.synchrony do
  results = []
  EM::Synchrony::FiberIterator.new([[1, 2], [3, 4]], 2).each { |list, iter| results.push(list) }
  results == [1, 3] # => true
  EM.stop
end
```

The issue happened because `FiberIterator` sends a nested array to `EventMachine::Synchrony::Iterator`  inside a `foreach` block. Thus, the array becomes a list of arguments.