### PR TITLE
Make tests runnable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem 'activerecord', "= #{ENV['activerecord'] || '4.1.8'}"
   gem 'em-mongo'
   gem 'bson_ext'
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.18'
   gem 'em-redis', '~> 0.3.0'
   gem 'em-hiredis'
   gem 'mongo'


### PR DESCRIPTION
TravisCI failed to load a `mysql2` adapter for `ActiveRecord`, e.g. https://travis-ci.org/igrigorik/em-synchrony/builds/102289375.

Probably, it is related to the issue rails/rails#21544 (found it [here](https://stackoverflow.com/questions/32457657/rails-4-gemloaderror-specified-mysql2-for-database-adapter-but-the-gem-i)). This fix rails/rails@5da5e37 hasn't been released yet.