### PR TITLE
Handle calling Kernel#sleep with no arguments

### DIFF
--- a/lib/em-synchrony/kernel.rb
+++ b/lib/em-synchrony/kernel.rb
@@ -10,18 +10,18 @@ module Kernel
   end
 
   # Monkey-patch
-  def sleep(sleep_time)
+  def sleep(*args)
     if Kernel.em_synchrony_sleep_hook &&
        EM.reactor_thread? &&
        !Thread.current[:em_synchrony_sleep_hook_called]
       begin
         Thread.current[:em_synchrony_sleep_hook_called] = true
-        Kernel.em_synchrony_sleep_hook.call(sleep_time)
+        Kernel.em_synchrony_sleep_hook.call(args[0])
       ensure
         Thread.current[:em_synchrony_sleep_hook_called] = false
       end
     else
-      orig_sleep(sleep_time)
+      orig_sleep(*args)
     end
   end
 end

--- a/spec/kernel_override_spec.rb
+++ b/spec/kernel_override_spec.rb
@@ -14,6 +14,18 @@ describe EventMachine::Synchrony do
         EM::Synchrony.on_sleep { fail 'should not happen' }
         expect { sleep(0.01) }.not_to raise_error
       end
+
+      it 'works when calling with no arguments' do
+        t = Thread.new do
+          expect { sleep }.to_not raise_error
+        end
+        while t.status
+          if t.status == 'sleep'
+            t.run
+          end
+        end
+        t.join
+      end
       context 'with synchrony in another thread'do
         before do
           @thread = Thread.new do


### PR DESCRIPTION
It is valid to call Kernel#sleep with no arguments. When the EM
synchrony monkey patch for Kernel#sleep is loaded, it incorrectly
defines the method as taking exacly one argument. This makes calling
`sleep` throw an ArgumentError, even when the EM reactor is not running.