### PR TITLE
Support ActiveRecord 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
       script: "bundle exec rspec spec/activerecord_spec.rb"
     - env: "activerecord=4.2.0"
       script: "bundle exec rspec spec/activerecord_spec.rb"
+    - rvm: 2.3.1
+      env: "activerecord=5.0.0"
+      script: "bundle exec rspec spec/activerecord_spec.rb"
   allow_failures:
     - env: "activerecord=3.2.21"
     - env: "activerecord=4.2.0"

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -7,13 +7,11 @@ require 'em-synchrony/thread'
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionPool
-      def connection_with_synchrony
-        _fibered_mutex.synchronize { connection_without_synchrony }
+      def connection
+        _fibered_mutex.synchronize do
+          @reserved_connections[current_connection_id] ||= checkout
+        end
       end
-
-      alias_method_chain :connection, :synchrony
-
-      private
 
       def _fibered_mutex
         @fibered_mutex ||= EM::Synchrony::Thread::Mutex.new

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -7,11 +7,13 @@ require 'em-synchrony/thread'
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionPool
-      def connection
-        _fibered_mutex.synchronize do
-          @reserved_connections[current_connection_id] ||= checkout
-        end
+      def connection_with_synchrony
+        _fibered_mutex.synchronize { connection_without_synchrony }
       end
+
+      alias_method_chain :connection, :synchrony
+
+      private
 
       def _fibered_mutex
         @fibered_mutex ||= EM::Synchrony::Thread::Mutex.new

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -9,7 +9,11 @@ module ActiveRecord
     class ConnectionPool
       def connection
         _fibered_mutex.synchronize do
-          @reserved_connections[current_connection_id] ||= checkout
+          if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0')
+            @thread_cached_conns[connection_cache_key(Thread.current)] ||= checkout
+          else
+            @reserved_connections[current_connection_id] ||= checkout
+          end
         end
       end
 

--- a/lib/em-synchrony/activerecord.rb
+++ b/lib/em-synchrony/activerecord.rb
@@ -7,11 +7,15 @@ require 'em-synchrony/thread'
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionPool
-      def connection
-        _fibered_mutex.synchronize do
-          if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0')
+      if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0')
+        def connection
+          _fibered_mutex.synchronize do
             @thread_cached_conns[connection_cache_key(Thread.current)] ||= checkout
-          else
+          end
+        end
+      else
+        def connection
+          _fibered_mutex.synchronize do
             @reserved_connections[current_connection_id] ||= checkout
           end
         end


### PR DESCRIPTION
I was using em-synchrony in Rails 4.2. It works perfectly.

But em-synchrony couldn't be running after update Rails to 5.0. The error is something like this:

```
undefined local variable or method `current_connection_id' for #<ActiveRecord::ConnectionAdapters::ConnectionPool:0x000008135f5c38>
/usr/home/hyoshida/src/sample/vendor/bundle/ruby/2.3.0/gems/em-synchrony-1.0.5/lib/em-synchrony/activerecord.rb:12:in `block in connection'
/usr/home/hyoshida/src/sample/vendor/bundle/ruby/2.3.0/gems/em-synchrony-1.0.5/lib/em-synchrony/thread.rb:63:in `synchronize'
/usr/home/hyoshida/src/sample/vendor/bundle/ruby/2.3.0/gems/em-synchrony-1.0.5/lib/em-synchrony/activerecord.rb:11:in `connection'
```

I think the cause is the following change in ActiveRecord:

```ruby
# ActiveRecord::ConnectionAdapters::ConnectionPool#connection
AR 4.2: @reserved_connections[current_connection_id] ||= checkout
AR 5.0: @thread_cached_conns[connection_cache_key(Thread.current)] ||= checkout
```

I tried to fix this error. Hope you like it.