### PR TITLE
Use of Fixnum is deprecated. Patch compatible with Ruby versions < 2.4.

### DIFF
--- a/lib/active_record/connection_adapters/em_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/em_mysql2_adapter.rb
@@ -24,7 +24,7 @@ module ActiveRecord
         variable_assignments << "NAMES '#{encoding}'" if encoding
 
         wait_timeout = config[:wait_timeout]
-        wait_timeout = 2592000 unless wait_timeout.is_a?(Fixnum)
+        wait_timeout = 2592000 unless wait_timeout.is_a?(Integer)
         variable_assignments << "@@wait_timeout = #{wait_timeout}"
 
         conn.query("SET #{variable_assignments.join(', ')}")


### PR DESCRIPTION
Proposed fix for [issue 212](https://github.com/igrigorik/em-synchrony/issues/212). Limited to use of Fixnum in AR MySQL connection adapter.